### PR TITLE
Test that leads to a tailer accessing discarded message ID.

### DIFF
--- a/splitlog-core/src/test/java/com/github/triceo/splitlog/LimitedMessageStoreTest.java
+++ b/splitlog-core/src/test/java/com/github/triceo/splitlog/LimitedMessageStoreTest.java
@@ -1,0 +1,62 @@
+package com.github.triceo.splitlog;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class LimitedMessageStoreTest extends DefaultTailerBaseTest {
+
+    private static final int CAPACITY = 1;
+    private static final int TIMEOUT_MILLIS = 10000;
+    private ExecutorService es;
+
+    @Before
+    public void setUp() {
+        this.es = Executors.newFixedThreadPool(2);
+    }
+
+    @After
+    public void tearDown() {
+        es.shutdownNow();
+        try {
+            es.awaitTermination(2, TimeUnit.SECONDS);
+        } catch (InterruptedException ex) {
+            System.err.println("Executor service failed to terminate.");
+        }
+    }
+
+    @Override
+    protected LogWatchBuilder getBuilder() {
+        return super.getBuilder().limitCapacityTo(CAPACITY);
+    }
+
+    @Test(timeout = TIMEOUT_MILLIS)
+    public void testLimitedMessageStore() throws InterruptedException, ExecutionException {
+        es.execute(new Runnable() {
+            @Override
+            public void run() {
+                while (true) {
+                    getWriter().writeWithoutWaiting("test");
+                }
+            }
+        });
+        final LogTailer tailer = getLogWatch().startTailing();
+        Future<?> reader = es.submit(new Runnable() {
+            @Override
+            public void run() {
+                long maxMillis = TIMEOUT_MILLIS / 2;
+                long start = System.currentTimeMillis();
+                while (System.currentTimeMillis() - start < maxMillis) {
+                    tailer.getMessages();
+                }
+            }
+        });
+        reader.get();
+    }
+}


### PR DESCRIPTION
It can happen that the oldest Message is discarded somewhere between obtaining its ID and asking for a message range, e.g. here https://github.com/triceo/splitlog/blob/383e111309aba9480f284177efbcb8e514b7ae68/splitlog-core/src/main/java/com/github/triceo/splitlog/DefaultLogWatch.java#L75-L89.

I suggest dropping the max(tailer_start_id, first_message_id) logic and always ask for the Tailer start ID. If the requested start ID is obsolete, MessageStore would produce an entry informing how many Messages were discarded.
